### PR TITLE
Bump qs and express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1593,41 +1593,6 @@
             "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
             "dev": true
         },
-        "body-parser": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-            "dev": true,
-            "requires": {
-                "bytes": "3.1.0",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "http-errors": "1.7.2",
-                "iconv-lite": "0.4.24",
-                "on-finished": "~2.3.0",
-                "qs": "6.7.0",
-                "raw-body": "2.4.0",
-                "type-is": "~1.6.17"
-            },
-            "dependencies": {
-                "bytes": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-                    "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-                    "dev": true
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
-            }
-        },
         "bonjour": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
@@ -1866,6 +1831,16 @@
                 "to-object-path": "^0.3.0",
                 "union-value": "^1.0.0",
                 "unset-value": "^1.0.0"
+            }
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
             }
         },
         "call-me-maybe": {
@@ -2262,15 +2237,6 @@
             "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
             "dev": true
         },
-        "content-disposition": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-            "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.2"
-            }
-        },
         "content-type": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -2285,12 +2251,6 @@
             "requires": {
                 "safe-buffer": "~5.1.1"
             }
-        },
-        "cookie": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-            "dev": true
         },
         "cookie-signature": {
             "version": "1.0.6",
@@ -2887,12 +2847,6 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
-        "destroy": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-            "dev": true
-        },
         "detect-file": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -3334,47 +3288,99 @@
             }
         },
         "express": {
-            "version": "4.17.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-            "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+            "version": "4.18.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.7",
+                "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.19.0",
-                "content-disposition": "0.5.3",
+                "body-parser": "1.20.1",
+                "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.4.0",
+                "cookie": "0.5.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
+                "depd": "2.0.0",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "~1.1.2",
+                "finalhandler": "1.2.0",
                 "fresh": "0.5.2",
+                "http-errors": "2.0.0",
                 "merge-descriptors": "1.0.1",
                 "methods": "~1.1.2",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.5",
-                "qs": "6.7.0",
+                "proxy-addr": "~2.0.7",
+                "qs": "6.11.0",
                 "range-parser": "~1.2.1",
-                "safe-buffer": "5.1.2",
-                "send": "0.17.1",
-                "serve-static": "1.14.1",
-                "setprototypeof": "1.1.1",
-                "statuses": "~1.5.0",
+                "safe-buffer": "5.2.1",
+                "send": "0.18.0",
+                "serve-static": "1.15.0",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
                 "type-is": "~1.6.18",
                 "utils-merge": "1.0.1",
                 "vary": "~1.1.2"
             },
             "dependencies": {
+                "accepts": {
+                    "version": "1.3.8",
+                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+                    "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+                    "dev": true,
+                    "requires": {
+                        "mime-types": "~2.1.34",
+                        "negotiator": "0.6.3"
+                    }
+                },
                 "array-flatten": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-                    "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+                    "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+                    "dev": true
+                },
+                "body-parser": {
+                    "version": "1.20.1",
+                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+                    "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.1.2",
+                        "content-type": "~1.0.4",
+                        "debug": "2.6.9",
+                        "depd": "2.0.0",
+                        "destroy": "1.2.0",
+                        "http-errors": "2.0.0",
+                        "iconv-lite": "0.4.24",
+                        "on-finished": "2.4.1",
+                        "qs": "6.11.0",
+                        "raw-body": "2.5.1",
+                        "type-is": "~1.6.18",
+                        "unpipe": "1.0.0"
+                    }
+                },
+                "bytes": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+                    "dev": true
+                },
+                "content-disposition": {
+                    "version": "0.5.4",
+                    "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+                    "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.2.1"
+                    }
+                },
+                "cookie": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+                    "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
                     "dev": true
                 },
                 "debug": {
@@ -3385,6 +3391,184 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "depd": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+                    "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+                    "dev": true
+                },
+                "destroy": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+                    "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+                    "dev": true
+                },
+                "finalhandler": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+                    "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "2.4.1",
+                        "parseurl": "~1.3.3",
+                        "statuses": "2.0.1",
+                        "unpipe": "~1.0.0"
+                    }
+                },
+                "forwarded": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+                    "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+                    "dev": true
+                },
+                "http-errors": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+                    "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "depd": "2.0.0",
+                        "inherits": "2.0.4",
+                        "setprototypeof": "1.2.0",
+                        "statuses": "2.0.1",
+                        "toidentifier": "1.0.1"
+                    }
+                },
+                "ipaddr.js": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+                    "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+                    "dev": true
+                },
+                "mime-db": {
+                    "version": "1.52.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+                    "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.35",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+                    "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.52.0"
+                    }
+                },
+                "negotiator": {
+                    "version": "0.6.3",
+                    "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+                    "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+                    "dev": true
+                },
+                "on-finished": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+                    "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+                    "dev": true,
+                    "requires": {
+                        "ee-first": "1.1.1"
+                    }
+                },
+                "proxy-addr": {
+                    "version": "2.0.7",
+                    "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+                    "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+                    "dev": true,
+                    "requires": {
+                        "forwarded": "0.2.0",
+                        "ipaddr.js": "1.9.1"
+                    }
+                },
+                "qs": {
+                    "version": "6.11.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+                    "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+                    "dev": true,
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
+                },
+                "raw-body": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+                    "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.1.2",
+                        "http-errors": "2.0.0",
+                        "iconv-lite": "0.4.24",
+                        "unpipe": "1.0.0"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "dev": true
+                },
+                "send": {
+                    "version": "0.18.0",
+                    "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+                    "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "depd": "2.0.0",
+                        "destroy": "1.2.0",
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.8.1",
+                        "fresh": "0.5.2",
+                        "http-errors": "2.0.0",
+                        "mime": "1.6.0",
+                        "ms": "2.1.3",
+                        "on-finished": "2.4.1",
+                        "range-parser": "~1.2.1",
+                        "statuses": "2.0.1"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.1.3",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "serve-static": {
+                    "version": "1.15.0",
+                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+                    "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+                    "dev": true,
+                    "requires": {
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "parseurl": "~1.3.3",
+                        "send": "0.18.0"
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+                    "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+                    "dev": true
+                },
+                "statuses": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+                    "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+                    "dev": true
+                },
+                "toidentifier": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+                    "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+                    "dev": true
                 }
             }
         },
@@ -3586,32 +3770,6 @@
                 }
             }
         },
-        "finalhandler": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-            "dev": true,
-            "requires": {
-                "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.3",
-                "statuses": "~1.5.0",
-                "unpipe": "~1.0.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
-            }
-        },
         "find-cache-dir": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -3667,12 +3825,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
-        },
-        "forwarded": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
             "dev": true
         },
         "fragment-cache": {
@@ -4321,6 +4473,25 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
+        "get-intrinsic": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.3"
+            },
+            "dependencies": {
+                "has-symbols": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                    "dev": true
+                }
+            }
+        },
         "get-stream": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -4663,27 +4834,6 @@
             "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
             "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
             "dev": true
-        },
-        "http-errors": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-            "dev": true,
-            "requires": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.1",
-                "statuses": ">= 1.5.0 < 2",
-                "toidentifier": "1.0.0"
-            },
-            "dependencies": {
-                "inherits": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
-                }
-            }
         },
         "http-parser-js": {
             "version": "0.4.10",
@@ -6191,15 +6341,6 @@
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
             "dev": true
         },
-        "on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-            "dev": true,
-            "requires": {
-                "ee-first": "1.1.1"
-            }
-        },
         "on-headers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
@@ -7244,16 +7385,6 @@
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
             "dev": true
         },
-        "proxy-addr": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-            "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
-            "dev": true,
-            "requires": {
-                "forwarded": "~0.1.2",
-                "ipaddr.js": "1.9.0"
-            }
-        },
         "prr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -7325,12 +7456,6 @@
             "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
             "dev": true
         },
-        "qs": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-            "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-            "dev": true
-        },
         "querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -7373,26 +7498,6 @@
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "dev": true
-        },
-        "raw-body": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-            "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-            "dev": true,
-            "requires": {
-                "bytes": "3.1.0",
-                "http-errors": "1.7.2",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "bytes": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-                    "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-                    "dev": true
-                }
-            }
         },
         "readable-stream": {
             "version": "2.3.6",
@@ -7814,52 +7919,6 @@
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "dev": true
         },
-        "send": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-            "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-            "dev": true,
-            "requires": {
-                "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "~1.7.2",
-                "mime": "1.6.0",
-                "ms": "2.1.1",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.2.1",
-                "statuses": "~1.5.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    },
-                    "dependencies": {
-                        "ms": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                            "dev": true
-                        }
-                    }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
-                }
-            }
-        },
         "serialize-javascript": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
@@ -7916,18 +7975,6 @@
                 }
             }
         },
-        "serve-static": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-            "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-            "dev": true,
-            "requires": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.17.1"
-            }
-        },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -7969,12 +8016,6 @@
             "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
             "dev": true
         },
-        "setprototypeof": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-            "dev": true
-        },
         "sha.js": {
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -8014,6 +8055,25 @@
             "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
             "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
             "dev": true
+        },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            },
+            "dependencies": {
+                "object-inspect": {
+                    "version": "1.12.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+                    "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+                    "dev": true
+                }
+            }
         },
         "signal-exit": {
             "version": "3.0.2",
@@ -8773,12 +8833,6 @@
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
             }
-        },
-        "toidentifier": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-            "dev": true
         },
         "tslib": {
             "version": "1.10.0",


### PR DESCRIPTION
Bumps [qs](https://github.com/ljharb/qs) and [express](https://github.com/expressjs/express). These dependencies needed to be updated together.

Updates `qs` from 6.7.0 to 6.11.0
- [Release notes](https://github.com/ljharb/qs/releases)
- [Changelog](https://github.com/ljharb/qs/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ljharb/qs/compare/v6.7.0...v6.11.0)

Updates `express` from 4.17.1 to 4.18.2
- [Release notes](https://github.com/expressjs/express/releases)
- [Changelog](https://github.com/expressjs/express/blob/master/History.md)
- [Commits](https://github.com/expressjs/express/compare/4.17.1...4.18.2)

---
updated-dependencies:
- dependency-name: qs dependency-type: indirect
- dependency-name: express dependency-type: indirect ...